### PR TITLE
Fix type module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "1.0.0-alpha.3",
+      "version": "1.0.0-alpha.4",
       "license": "MIT",
       "dependencies": {
-        "@placekit/client-js": "^1.0.0-alpha.1",
+        "@placekit/client-js": "^1.0.0-alpha.2",
         "@popperjs/core": "^2.11.6"
       },
       "devDependencies": {
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@placekit/client-js": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-0xsNeuXkSABAMV3+yuP/qE9nsGnLblvvxO4/ZyBOsxVCX0ipthTe3mk9C0pJUWsSg33rcl1dSt3ZcX/Kw+7baA=="
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-2shFA8v6sAiRE5SIHOKZaPjuZPhi0Pqwud61IrGhUkzqf3eVO5tvLCY6l7gjjHeBgDwHOkhrRcZ7p9auZgXQIg=="
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.6",
@@ -3542,9 +3542,9 @@
       }
     },
     "@placekit/client-js": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-0xsNeuXkSABAMV3+yuP/qE9nsGnLblvvxO4/ZyBOsxVCX0ipthTe3mk9C0pJUWsSg33rcl1dSt3ZcX/Kw+7baA=="
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-2shFA8v6sAiRE5SIHOKZaPjuZPhi0Pqwud61IrGhUkzqf3eVO5tvLCY6l7gjjHeBgDwHOkhrRcZ7p9auZgXQIg=="
     },
     "@popperjs/core": {
       "version": "2.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",
@@ -12,7 +12,6 @@
   "bugs": {
     "url": "https://github.com/placekit/autocomplete-js/issues"
   },
-  "type": "module",
   "types": "./dist/placekit-autocomplete.d.ts",
   "module": "./dist/placekit-autocomplete.esm.js",
   "main": "./dist/placekit-autocomplete.cjs.js",
@@ -56,7 +55,7 @@
     "rollup-plugin-postcss": "^4.0.2"
   },
   "dependencies": {
-    "@placekit/client-js": "^1.0.0-alpha.1",
+    "@placekit/client-js": "^1.0.0-alpha.2",
     "@popperjs/core": "^2.11.6"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,15 +1,15 @@
-import path from 'path';
+const path = require('path');
 
-import autoprefixer from 'autoprefixer';
-import commonjs from '@rollup/plugin-commonjs';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import replace from '@rollup/plugin-replace';
-import cleanup from 'rollup-plugin-cleanup';
-import copy from 'rollup-plugin-copy';
-import postcss from 'rollup-plugin-postcss';
-import postcssBanner from 'postcss-banner';
+const autoprefixer = require('autoprefixer');
+const commonjs = require('@rollup/plugin-commonjs');
+const { nodeResolve } = require('@rollup/plugin-node-resolve');
+const replace = require('@rollup/plugin-replace');
+const cleanup = require('rollup-plugin-cleanup');
+const copy = require('rollup-plugin-copy');
+const postcss = require('rollup-plugin-postcss');
+const postcssBanner = require('postcss-banner');
 
-import pkg from './package.json' assert { type: "json" };
+const pkg = require('./package.json');
 const banner = [
   `/*! ${pkg.name} v${pkg.version}`,
   '© placekit.io',
@@ -17,7 +17,7 @@ const banner = [
   `${pkg.homepage} */`,
 ].join(' | ');
 
-export default {
+module.exports = {
   input: 'src/index.js',
   output: [
     {


### PR DESCRIPTION
- Remove `"type": "module"` causing import error in (at least) Next.js.
- Update `rollup.config.js` to use `require` instead of `import` to prevent build error.