### PR TITLE
Disable overflow flipping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "1.0.0-alpha.4",
+      "version": "1.0.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^1.0.0-alpha.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -157,12 +157,11 @@ module.exports = (apiKey, options = {}) => {
   // Popper.js for panel positionning
   const popperInstance = createPopper(input, suggestionsPanel, {
     placement: 'bottom-start',
+    container: 'body',
     modifiers: [
       {
-        name: 'preventOverflow',
-        options: {
-          padding: 8,
-        },
+        name: 'flip',
+        enabled: false,
       },
       {
         name: 'offset',


### PR DESCRIPTION
- Disable flipping top when suggestions panel is overflowing.
- Move suggestions panel to the `body` container.