### PR TITLE
Add panel options

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ console.log(pka.options); // { "target": <input ... />, "language": "en", "maxRe
 | `formatValue` | AutoComplete | `(item: object) => string` | [see index.js](./src/index.js#L40) | Input value formatting function when selected from list. |
 | `strategy` | AutoComplete | `'absolute' | 'fixed'` | `absolute` | [Popper positionning strategy](https://popper.js.org/docs/v2/constructors/#strategy) |
 | `flip` | AutoComplete | `boolean` | `false` | Flip position top when overflowing |
-| `className` | AutoComplete | `string` | `''` | Additional suggestions panel CSS class(es) |
+| `className` | AutoComplete | `string` | `undefined` | Additional suggestions panel CSS class(es) |
 | `maxResults` | JS client | `integer` | `5` | Number of results per page. |
 | `language` | JS client | `string?` | `undefined` | Language of the results, two-letter ISO language code. |
 | `types` | JS client | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ console.log(pka.options); // { "target": <input ... />, "language": "en", "maxRe
 | `offset` | AutoComplete | `integer` | `4` | Gap between input and suggestions list in pixels. |
 | `template` | AutoComplete | `(item: object) => string` | [see index.js](./src/index.js#L24-L39) | Suggestion item formatting function. |
 | `formatValue` | AutoComplete | `(item: object) => string` | [see index.js](./src/index.js#L40) | Input value formatting function when selected from list. |
-| `strategy` | AutoComplete | `'absolute' | 'fixed'` | `absolute` | [Popper positionning strategy](https://popper.js.org/docs/v2/constructors/#strategy) |
-| `flip` | AutoComplete | `boolean` | `false` | Flip position top when overflowing |
-| `className` | AutoComplete | `string` | `undefined` | Additional suggestions panel CSS class(es) |
+| `strategy` | AutoComplete | `'absolute' | 'fixed'` | `absolute` | [Popper positioning strategy](https://popper.js.org/docs/v2/constructors/#strategy) |
+| `flip` | AutoComplete | `boolean` | `false` | Flip position top when overflowing. |
+| `className` | AutoComplete | `string` | `undefined` | Additional suggestions panel CSS class(es). |
 | `maxResults` | JS client | `integer` | `5` | Number of results per page. |
 | `language` | JS client | `string?` | `undefined` | Language of the results, two-letter ISO language code. |
 | `types` | JS client | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ console.log(pka.options); // { "target": <input ... />, "language": "en", "maxRe
 | `target` | AutoComplete | `string\|Element` | `-` | Target input element or (unique) selector. |
 | `offset` | AutoComplete | `integer` | `4` | Gap between input and suggestions list in pixels. |
 | `template` | AutoComplete | `(item: object) => string` | [see index.js](./src/index.js#L24-L39) | Suggestion item formatting function. |
-| `formatValue` | AutoComplete | `(item: object) => string` | [see index.js](./src/index.js#L40) | Input value formatting function when selected from list. }
+| `formatValue` | AutoComplete | `(item: object) => string` | [see index.js](./src/index.js#L40) | Input value formatting function when selected from list. |
+| `strategy` | AutoComplete | `'absolute' | 'fixed'` | `absolute` | [Popper positionning strategy](https://popper.js.org/docs/v2/constructors/#strategy) |
+| `flip` | AutoComplete | `boolean` | `false` | Flip position top when overflowing |
+| `className` | AutoComplete | `string` | `''` | Additional suggestions panel CSS class(es) |
 | `maxResults` | JS client | `integer` | `5` | Number of results per page. |
 | `language` | JS client | `string?` | `undefined` | Language of the results, two-letter ISO language code. |
 | `types` | JS client | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "1.0.0-alpha.5",
+      "version": "1.0.0-alpha.6",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^1.0.0-alpha.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -41,4 +41,7 @@ export type PKAOptions = PKOptions & {
   offset?: number;
   template?: (item: PKResult) => string;
   formatValue?: (item: PKResult) => string;
+  strategy?: 'absolute' | 'fixed';
+  flip?: boolean;
+  className?: string;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,6 @@ module.exports = (apiKey, options = {}) => {
     formatValue: (item) => item.name,
     strategy: 'absolute',
     flip: false,
-    className: '',
     ...options,
   };
 
@@ -136,7 +135,9 @@ module.exports = (apiKey, options = {}) => {
   // suggestions panel
   const suggestionsPanel = document.createElement('div');
   suggestionsPanel.classList.add('pka-suggestions');
-  suggestionsPanel.classList.add(...className.split(/\s+/));
+  if (typeof className === 'string') {
+    suggestionsPanel.classList.add(...className.split(/\s+/));
+  }
 
   // suggestions list
   const suggestionsList = document.createElement('div');

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,9 @@ require('./placekit.css');
  * @prop {number} [offset] Suggestions panel vertical offset (in px)
  * @prop {Template} [template] Suggestion item template
  * @prop {FormatValue} [formatValue] Return value formatting function
+ * @prop {'absolute'|'fixed'} [strategy] Popper positionning strategy (see https://popper.js.org/docs/v2/constructors/#strategy)
+ * @prop {boolean} [flip] Flip when overflowing (defaults to false)
+ * @prop {string} [className] Additional panel class name
  */
 
 /**
@@ -75,6 +78,9 @@ module.exports = (apiKey, options = {}) => {
     offset,
     template,
     formatValue,
+    strategy,
+    flip,
+    className,
     ...pkOptions
   } = {
     target: '#placekit',
@@ -96,16 +102,19 @@ module.exports = (apiKey, options = {}) => {
       `;
     },
     formatValue: (item) => item.name,
+    strategy: 'absolute',
+    flip: false,
+    className: '',
     ...options,
   };
 
   // throw error if invalid options
   if (!template?.call) {
-    throw (`Error: options.template must be a function returning a string.`);
+    throw (`TypeError: options.template must be a function returning a string.`);
   }
 
   if (!formatValue?.call) {
-    throw (`Error: options.formatValue must be a function returning a string.`);
+    throw (`TypeError: options.formatValue must be a function returning a string.`);
   }
 
   const input = typeof target === 'string' ? document.querySelector(target) : target;
@@ -127,6 +136,7 @@ module.exports = (apiKey, options = {}) => {
   // suggestions panel
   const suggestionsPanel = document.createElement('div');
   suggestionsPanel.classList.add('pka-suggestions');
+  suggestionsPanel.classList.add(...className.split(/\s+/));
 
   // suggestions list
   const suggestionsList = document.createElement('div');
@@ -157,11 +167,11 @@ module.exports = (apiKey, options = {}) => {
   // Popper.js for panel positionning
   const popperInstance = createPopper(input, suggestionsPanel, {
     placement: 'bottom-start',
-    container: 'body',
+    strategy,
     modifiers: [
       {
         name: 'flip',
-        enabled: false,
+        enabled: flip,
       },
       {
         name: 'offset',


### PR DESCRIPTION
- Add `strategy` option to configure popper positioning strategy (see https://popper.js.org/docs/v2/constructors/#strategy).
- Add `flip` option to configure overflow behavior.
- Add `className` option to append classes to the suggestions panel.