### PR TITLE
Container queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ Colors, border-radius, font and overall scale (in `rem`) are accessible over var
   --pka-color-white: 255, 255, 255;
   --pka-border-radius: 6px;
   --pka-font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --pka-z-index: 9999;
 }
 
 /* dark mode overrides */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,17 +13,17 @@
         "@popperjs/core": "^2.11.7"
       },
       "devDependencies": {
-        "@rollup/plugin-commonjs": "^24.0.1",
+        "@rollup/plugin-commonjs": "^24.1.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@rollup/plugin-replace": "^5.0.2",
         "autoprefixer": "^10.4.14",
         "eslint": "^8.38.0",
         "eslint-config-google": "^0.14.0",
         "npm-watch": "^0.11.0",
-        "postcss": "^8.4.21",
+        "postcss": "^8.4.22",
         "postcss-banner": "^4.0.1",
         "rimraf": "^5.0.0",
-        "rollup": "^3.20.2",
+        "rollup": "^3.20.6",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-postcss": "^4.0.2"
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-24.0.1.tgz",
-      "integrity": "sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-24.1.0.tgz",
+      "integrity": "sha512-eSL45hjhCWI0jCCXcNtLVqM5N1JlBGvlFfY0m6oOYnLCJ6N0qEXoZql4sY2MOUArzhH4SA/qBpTxvvZp2Sc+DQ==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
@@ -1936,10 +1936,16 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2284,9 +2290,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.22.tgz",
+      "integrity": "sha512-XseknLAfRHzVWjCEtdviapiBtfLdgyzExD50Rg2ePaucEesyh8Wv4VPdW0nbyDa1ydbrAxV19jvMT4+LFmcNUA==",
       "dev": true,
       "funding": [
         {
@@ -2296,10 +2302,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -3023,9 +3033,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
-      "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.6.tgz",
+      "integrity": "sha512-2yEB3nQXp/tBQDN0hJScJQheXdvU2wFhh6ld7K/aiZ1vYcak6N/BKjY1QrU6BvO2JWYS8bEs14FRaxXosxy2zw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3677,9 +3687,9 @@
       "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw=="
     },
     "@rollup/plugin-commonjs": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-24.0.1.tgz",
-      "integrity": "sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-24.1.0.tgz",
+      "integrity": "sha512-eSL45hjhCWI0jCCXcNtLVqM5N1JlBGvlFfY0m6oOYnLCJ6N0qEXoZql4sY2MOUArzhH4SA/qBpTxvvZp2Sc+DQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^5.0.1",
@@ -4949,9 +4959,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true
     },
     "natural-compare": {
@@ -5193,12 +5203,12 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.22.tgz",
+      "integrity": "sha512-XseknLAfRHzVWjCEtdviapiBtfLdgyzExD50Rg2ePaucEesyh8Wv4VPdW0nbyDa1ydbrAxV19jvMT4+LFmcNUA==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -5656,9 +5666,9 @@
       }
     },
     "rollup": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.2.tgz",
-      "integrity": "sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==",
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.6.tgz",
+      "integrity": "sha512-2yEB3nQXp/tBQDN0hJScJQheXdvU2wFhh6ld7K/aiZ1vYcak6N/BKjY1QrU6BvO2JWYS8bEs14FRaxXosxy2zw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -39,17 +39,17 @@
     "format": "eslint ./src --fix"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^24.0.1",
+    "@rollup/plugin-commonjs": "^24.1.0",
     "@rollup/plugin-node-resolve": "^15.0.2",
     "@rollup/plugin-replace": "^5.0.2",
     "autoprefixer": "^10.4.14",
     "eslint": "^8.38.0",
     "eslint-config-google": "^0.14.0",
     "npm-watch": "^0.11.0",
-    "postcss": "^8.4.21",
+    "postcss": "^8.4.22",
     "postcss-banner": "^4.0.1",
     "rimraf": "^5.0.0",
-    "rollup": "^3.20.2",
+    "rollup": "^3.20.6",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-postcss": "^4.0.2"

--- a/src/placekit.css
+++ b/src/placekit.css
@@ -198,6 +198,8 @@ body[data-theme="dark"] .pka-input-clear:hover {
  * ----------------------------------------
  */
 .pka-suggestions {
+  container-name: pka-suggestions;
+  container-type: inline-size;
   z-index: var(--pka-z-index);
   visibility: hidden;
   pointer-events: none;
@@ -249,7 +251,7 @@ body[data-theme="dark"] .pka-suggestions {
   padding: .375em .625em;
 }
 
-@media (min-width: 360px) {
+@container pka-suggestions (min-width: 420px) {
   .pka-suggestions-item {
     padding: .625em;
   }
@@ -302,7 +304,7 @@ body[data-theme="dark"] .pka-suggestions-item[aria-disabled="true"] .pka-suggest
   font-size: .75em;
 }
 
-@media (min-width: 360px) {
+@container pka-suggestions (min-width: 420px) {
   .pka-suggestions-item-label {
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/placekit.css
+++ b/src/placekit.css
@@ -23,6 +23,7 @@
   --pka-color-white: 255, 255, 255;
   --pka-border-radius: 6px;
   --pka-font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --pka-z-index: 9999;
 }
 
 /* dark mode overrides */
@@ -197,7 +198,7 @@ body[data-theme="dark"] .pka-input-clear:hover {
  * ----------------------------------------
  */
 .pka-suggestions {
-  z-index: 9999;
+  z-index: var(--pka-z-index);
   visibility: hidden;
   pointer-events: none;
   overflow: hidden;


### PR DESCRIPTION
- Expose `--pka-z-index` CSS variable to change the zIndex value for the suggestions panel, default to `9999`.
- Replace suggestions panel media queries with container queries. Widely supported today, fallbacks to showing result items on 2 lines instead of one when not supported. Show result items on 2 lines when container width <= 420px, previously screen width <= 320px.

As of today
<img width="1447" alt="image" src="https://user-images.githubusercontent.com/1834312/233090817-a7e43faa-2bab-4cc6-a6b6-1289f494039c.png">
