### PR TITLE
Fix: scroll on keyboard nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For React implementations, check our [PlaceKit Autocomplete React](https://githu
 First, import the library and the default stylesheet into the `<head>` tag in your HTML:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@placekit/autocomplete-js@1.1.2/dist/placekit-autocomplete.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@placekit/autocomplete-js@1.1.3/dist/placekit-autocomplete.min.css" />
 <script src="https://cdn.jsdelivr.net/npm/@placekit/autocomplete-js"></script>
 ```
 
@@ -65,7 +65,7 @@ Or if you are using native ES Modules:
 
 ```html
 <script type="module">
-  import placekit from 'https://cdn.jsdelivr.net/npm/@placekit/autocomplete-js@1.1.2/dist/placekit-autocomplete.esm.js';
+  import placekit from 'https://cdn.jsdelivr.net/npm/@placekit/autocomplete-js@1.1.3/dist/placekit-autocomplete.esm.js';
   const pka = placekitAutocomplete(/* ... */);
   // ...
 </script>

--- a/examples/autocomplete-js-address-form/package-lock.json
+++ b/examples/autocomplete-js-address-form/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@placekit/autocomplete-js": "^1.1.2",
+        "@placekit/autocomplete-js": "^1.1.3",
         "@tailwindcss/forms": "^0.5.3"
       },
       "devDependencies": {

--- a/examples/autocomplete-js-address-form/package.json
+++ b/examples/autocomplete-js-address-form/package.json
@@ -13,7 +13,7 @@
     "vite": "^4.3.2"
   },
   "dependencies": {
-    "@placekit/autocomplete-js": "^1.1.2",
+    "@placekit/autocomplete-js": "^1.1.3",
     "@tailwindcss/forms": "^0.5.3"
   }
 }

--- a/examples/autocomplete-js-basic/package-lock.json
+++ b/examples/autocomplete-js-basic/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@placekit/autocomplete-js": "^1.1.2"
+        "@placekit/autocomplete-js": "^1.1.3"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.14",

--- a/examples/autocomplete-js-basic/package.json
+++ b/examples/autocomplete-js-basic/package.json
@@ -13,6 +13,6 @@
     "vite": "^4.3.2"
   },
   "dependencies": {
-    "@placekit/autocomplete-js": "^1.1.2"
+    "@placekit/autocomplete-js": "^1.1.3"
   }
 }

--- a/examples/autocomplete-js-cdn/index.html
+++ b/examples/autocomplete-js-cdn/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
   <title>PlaceKit Autocomplete JS from CDN</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@placekit/autocomplete-js@1.1.2/dist/placekit-autocomplete.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@placekit/autocomplete-js@1.1.3/dist/placekit-autocomplete.min.css" />
   <style>
     body { padding: 4rem; }
     .container {

--- a/examples/autocomplete-js-geolocation-dark/package-lock.json
+++ b/examples/autocomplete-js-geolocation-dark/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@placekit/autocomplete-js": "^1.1.2"
+        "@placekit/autocomplete-js": "^1.1.3"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.14",

--- a/examples/autocomplete-js-geolocation-dark/package.json
+++ b/examples/autocomplete-js-geolocation-dark/package.json
@@ -13,6 +13,6 @@
     "vite": "^4.3.2"
   },
   "dependencies": {
-    "@placekit/autocomplete-js": "^1.1.2"
+    "@placekit/autocomplete-js": "^1.1.3"
   }
 }

--- a/examples/autocomplete-js-geolocation/package-lock.json
+++ b/examples/autocomplete-js-geolocation/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@placekit/autocomplete-js": "^1.1.2"
+        "@placekit/autocomplete-js": "^1.1.3"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.14",

--- a/examples/autocomplete-js-geolocation/package.json
+++ b/examples/autocomplete-js-geolocation/package.json
@@ -13,6 +13,6 @@
     "vite": "^4.3.2"
   },
   "dependencies": {
-    "@placekit/autocomplete-js": "^1.1.2"
+    "@placekit/autocomplete-js": "^1.1.3"
   }
 }

--- a/examples/autocomplete-js-leaflet/package-lock.json
+++ b/examples/autocomplete-js-leaflet/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@placekit/autocomplete-js": "^1.1.2",
+        "@placekit/autocomplete-js": "^1.1.3",
         "leaflet": "^1.9.3"
       },
       "devDependencies": {

--- a/examples/autocomplete-js-leaflet/package.json
+++ b/examples/autocomplete-js-leaflet/package.json
@@ -13,7 +13,7 @@
     "vite": "^4.3.2"
   },
   "dependencies": {
-    "@placekit/autocomplete-js": "^1.1.2",
+    "@placekit/autocomplete-js": "^1.1.3",
     "leaflet": "^1.9.3"
   }
 }

--- a/examples/autocomplete-js-typescript/package-lock.json
+++ b/examples/autocomplete-js-typescript/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@placekit/autocomplete-js": "^1.1.2"
+        "@placekit/autocomplete-js": "^1.1.3"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.14",

--- a/examples/autocomplete-js-typescript/package.json
+++ b/examples/autocomplete-js-typescript/package.json
@@ -14,6 +14,6 @@
     "vite": "^4.3.2"
   },
   "dependencies": {
-    "@placekit/autocomplete-js": "^1.1.2"
+    "@placekit/autocomplete-js": "^1.1.3"
   }
 }

--- a/examples/autocomplete-js-vue/package.json
+++ b/examples/autocomplete-js-vue/package.json
@@ -7,7 +7,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@placekit/autocomplete-js": "^1.1.2",
+    "@placekit/autocomplete-js": "^1.1.3",
     "vue": "^3.2.47"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -281,6 +281,9 @@ module.exports = (apiKey, options = {}) => {
     clearActive();
     const current = Math.max(0, Math.min(suggestions.length - 1, prev + n));
     suggestions[current].element.classList.add('pka-active');
+    suggestionsList.scrollTo({
+      top: suggestions[current].element.offsetTop,
+    });
     if (prev + n < 0) {
       togglePanel(false);
     }
@@ -360,6 +363,11 @@ module.exports = (apiKey, options = {}) => {
         case 'Enter':
           if (isPanelOpen) {
             e.preventDefault();
+            applySelection();
+          }
+          break;
+        case 'ArrowRight':
+          if (isPanelOpen && input.selectionEnd === input.value.length) {
             applySelection();
           }
           break;


### PR DESCRIPTION
- Scroll suggestions list to follow keyboard navigation
- Add `ArrowRight` support, applies selection the same way as `Enter` but only when the cursor is at the end of the input.