### PR TITLE
feat:configure now accepts all options

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ If you have trouble importing CSS from `node_modules`, copy/paste [its content](
 - [`pka.on()`](#pkaon)
 - [`pka.handlers`](#pkahandlers)
 - [`pka.requestGeolocation()`](#pkarequestGeolocation)
-- [`pka.hasGeolocation`](#pkahasGeolocation)
 - [`pka.open()`](#pkaopen)
 - [`pka.close()`](#pkaclose)
 - [`pka.clear()`](#pkaclear)
@@ -235,7 +234,7 @@ pka.configure({
 Read-only object of input state.
 
 ```js
-console.log(pka.state); // {dirty: false, empty: false, freeForm: true}
+console.log(pka.state); // {dirty: false, empty: false, freeForm: true, geolocation: false}
 
 // `true` after the user modifies the input value.
 console.log(pka.state.dirty); // true or false
@@ -245,6 +244,9 @@ console.log(pka.state.empty); // true or false
 
 // `true` if the input has a free form value or `false` if value is selected from the suggestions.
 console.log(pka.state.freeForm); // true or false
+
+// `true` if device geolocation has been granted.
+console.log(pka.state.geolocation); // true or false
 ```
 
 The `freeForm` value comes handy if you need to implement a strict validation of the address, but we don't interfere with how to implement it as input validation is always very specific to the project's stack.
@@ -259,11 +261,11 @@ pka.on('open', () => {})
   .on('results', (query, results) => {})
   .on('pick', (value, item, index) => {})
   .on('error', (error) => {})
-  .on('dirty', (dirty) => {})
-  .on('empty', (empty) => {})
-  .on('freeForm', (freeForm) => {})
+  .on('dirty', (bool) => {})
+  .on('empty', (bool) => {})
+  .on('freeForm', (bool) => {})
+  .on('geolocation', (bool, position) => {});
   .on('state', (state) => {})
-  .on('geolocation', (hasGeolocation, position) => {});
 ```
 
 If you register a same event twice, the first one will be replaced.
@@ -334,6 +336,15 @@ Triggered when input value changes.
 | --- | --- | --- |
 | `freeForm` | `boolean` | `true` on user input, `false` on `pick` event. |
 
+##### `geolocation`
+
+Triggered when `state.geolocation` value changes (a.k.a. when `pka.requestGeolocation` is called).
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `geolocation` | `boolean` | `true` if granted, `false` if denied. |
+| `position` | [`GeolocationPosition \| undefined`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPosition) | Passed when `geolocation` is `true`. |
+
 ##### `state`
 
 Triggered when one of the input states changes.
@@ -341,15 +352,6 @@ Triggered when one of the input states changes.
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `state` | `object` | The current input state. |
-
-##### `geolocation`
-
-Triggered when `hasGeolocation` value changes (a.k.a. when `pka.requestGeolocation` is called).
-
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `hasGeolocation` | `boolean` | `true` if granted, `false` if denied. |
-| `position` | [`GeolocationPosition`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPosition) | Passed when `hasGeolocation` is `true`. |
 
 ### `pka.handlers`
 
@@ -374,14 +376,6 @@ pka.requestGeolocation({ timeout: 10000 }).then((pos) => console.log(pos.coords)
 | `cancelUpdate` | `boolean` (optional) | If `false` (default), suggestions list updates immediately based on device location. |
 
 The location will be store in the `coordinates` global options, you can still manually override it.
-
-### `pka.hasGeolocation`
-
-Reads if device geolocation is activated or not (read-only).
-
-```js
-console.log(pka.hasGeolocation); // true or false
-```
 
 ### `pka.open()`
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ const pka = placekitAutocomplete('<your-api-key>', {
 | `apiKey` | `string` | API key |
 | `options` | `key-value mapping` (optional) | Global parameters (see [options](#pkaoptions)) |
 
+⚠️ `target` must be set when instanciating `placekitAutocomplete`, all other options can be set later with [`pka.configure()`](#pkaconfigure).
+
 ### `pka.input`
 
 Input field element passed as `target` option, read-only.
@@ -212,10 +214,13 @@ See our [country field example](./example/autocomplete-js-country).
 
 ### `pka.configure()`
 
-Updates search parameters (only JS client options!). Returns the instance so you can chain methods.
+Updates all parameters (**except `target`**). Returns the instance so you can chain methods.
 
 ```js
 pka.configure({
+  className: 'my-suggestions',
+  flip: true,
+  formatValue: (item) => `${item.name} ${item.city}`,
   language: 'fr',
   maxResults: 5,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,6 +9,7 @@ export type PKAState = {
   dirty: boolean;
   empty: boolean;
   freeForm: boolean;
+  geolocation: boolean;
 };
 
 export interface PKAClient {
@@ -23,11 +24,10 @@ export interface PKAClient {
   on(event: 'dirty', handler?: PKAHandlers['dirty']): PKAClient;
   on(event: 'empty', handler?: PKAHandlers['empty']): PKAClient;
   on(event: 'freeForm', handler?: PKAHandlers['freeForm']): PKAClient;
-  on(event: 'state', handler?: PKAHandlers['state']): PKAClient;
   on(event: 'geolocation', handler?: PKAHandlers['geolocation']): PKAClient;
+  on(event: 'state', handler?: PKAHandlers['state']): PKAClient;
   readonly handlers: Partial<PKAHandlers>;
   readonly state: PKAState;
-  readonly hasGeolocation: boolean;
   requestGeolocation(opts?: Object, cancelUpdate?: boolean): Promise<GeolocationPosition>;
   open(): PKAClient;
   close(): PKAClient;
@@ -41,11 +41,11 @@ export type PKAHandlers = {
   results: (query: string, results: PKResult[]) => void;
   pick: (value: string, item: PKResult, index: number) => void;
   error: (error: Object) => void;
-  dirty: (dirty: boolean) => void;
-  empty: (empty: boolean) => void;
-  freeForm: (freeForm: boolean) => void;
+  dirty: (bool: boolean) => void;
+  empty: (bool: boolean) => void;
+  freeForm: (bool: boolean) => void;
+  geolocation: (bool: boolean, position?: GeolocationPosition) => void;
   state: (state: PKAState) => void;
-  geolocation: (hasGeolocation: boolean, position?: GeolocationPosition) => void;
 };
 
 export type PKAOptions = PKOptions & {

--- a/src/index.js
+++ b/src/index.js
@@ -599,7 +599,6 @@ module.exports = (apiKey, { target = '#placekit', ...initOptions } = {}) => {
           setValue(value, {
             preview: false,
             focus: false,
-            dirty: false,
             freeForm: false,
           });
           fireEvent('pick', value, results[0], 0);

--- a/src/index.js
+++ b/src/index.js
@@ -247,16 +247,15 @@ module.exports = (apiKey, { target = '#placekit', ...initOptions } = {}) => {
    * @arg {string} [value] New input value
    * @arg {bool} [preview=false] `true` to prevent change event
    */
-  function setValue(value, { preview = false, focus = true, freeForm = true } = {}) {
+  function setValue(value, { preview = false, focus = true, ...newState } = {}) {
     if (isString(value)) {
       input.value = value;
       if (!preview) {
         input.dispatchEvent(new Event('change'));
         storeValue();
         setState({
-          dirty: true,
           empty: !input.value,
-          freeForm,
+          ...newState,
         });
       }
       if (focus) {
@@ -375,7 +374,7 @@ module.exports = (apiKey, { target = '#placekit', ...initOptions } = {}) => {
       });
       current.element.classList.add('pka-selected');
       current.element.setAttribute('aria-selected', true);
-      setValue(current.value, { freeForm: false });
+      setValue(current.value, { dirty: true, freeForm: false });
       fireEvent('pick', input.value, current.item, index);
     }
   }
@@ -482,7 +481,7 @@ module.exports = (apiKey, { target = '#placekit', ...initOptions } = {}) => {
       if (e.target.classList.contains('pka-suggestions-item-action')) {
         const current = suggestions[index];
         if (current) {
-          setValue(`${current.value} `); // add trailing space
+          setValue(`${current.value} `, { dirty: true, freeform: false }); // add trailing space
         }
       } else {
         applySuggestion(index);
@@ -600,6 +599,7 @@ module.exports = (apiKey, { target = '#placekit', ...initOptions } = {}) => {
           setValue(value, {
             preview: false,
             focus: false,
+            dirty: false,
             freeForm: false,
           });
           fireEvent('pick', value, results[0], 0);


### PR DESCRIPTION
- `pka.configure()` now accepts all options, except `target` which must be set at init time.
- Update PlaceKit client, PopperJS instance when calling `pka.configure()`.
- Fix `countryAutoFill` to make it run only when input is empty.
- **BREAKING** move `hasGeolocation` to `state.geolocation`.