### PR TITLE
Fix default value clearing bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
-        "@rollup/plugin-commonjs": "^25.0.0",
+        "@rollup/plugin-commonjs": "^25.0.1",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@rollup/plugin-replace": "^5.0.2",
         "autoprefixer": "^10.4.14",
@@ -23,7 +23,7 @@
         "postcss": "^8.4.24",
         "postcss-banner": "^4.0.1",
         "rimraf": "^5.0.1",
-        "rollup": "^3.23.1",
+        "rollup": "^3.25.1",
         "rollup-plugin-cleanup": "^3.2.1",
         "rollup-plugin-copy": "^3.4.0",
         "rollup-plugin-postcss": "^4.0.2"
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.0.tgz",
-      "integrity": "sha512-hoho2Kay9TZrLu0bnDsTTCaj4Npa+THk9snajP/XDNb9a9mmjTjh52EQM9sKl3HD1LsnihX7js+eA2sd2uKAhw==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.1.tgz",
+      "integrity": "sha512-2DJ4kv4b1xfTJopWhu61ANdNRHvzQZ2fpaIrlgaP2jOfUv1wDJ0Ucqy8AZlbFmn/iUjiwKoqki9j55Y6L8kyNQ==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
@@ -3142,9 +3142,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.23.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.23.1.tgz",
-      "integrity": "sha512-ybRdFVHOoljGEFILHLd2g/qateqUdjE6YS41WXq4p3C/WwD3xtWxV4FYWETA1u9TeXQc5K8L8zHE5d/scOvrOQ==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.25.1.tgz",
+      "integrity": "sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4018,9 +4018,9 @@
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@rollup/plugin-commonjs": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.0.tgz",
-      "integrity": "sha512-hoho2Kay9TZrLu0bnDsTTCaj4Npa+THk9snajP/XDNb9a9mmjTjh52EQM9sKl3HD1LsnihX7js+eA2sd2uKAhw==",
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.1.tgz",
+      "integrity": "sha512-2DJ4kv4b1xfTJopWhu61ANdNRHvzQZ2fpaIrlgaP2jOfUv1wDJ0Ucqy8AZlbFmn/iUjiwKoqki9j55Y6L8kyNQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^5.0.1",
@@ -6029,9 +6029,9 @@
       }
     },
     "rollup": {
-      "version": "3.23.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.23.1.tgz",
-      "integrity": "sha512-ybRdFVHOoljGEFILHLd2g/qateqUdjE6YS41WXq4p3C/WwD3xtWxV4FYWETA1u9TeXQc5K8L8zHE5d/scOvrOQ==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.25.1.tgz",
+      "integrity": "sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "format": "eslint ./src --fix"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^25.0.0",
+    "@rollup/plugin-commonjs": "^25.0.1",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-replace": "^5.0.2",
     "autoprefixer": "^10.4.14",
@@ -49,7 +49,7 @@
     "postcss": "^8.4.24",
     "postcss-banner": "^4.0.1",
     "rimraf": "^5.0.1",
-    "rollup": "^3.23.1",
+    "rollup": "^3.25.1",
     "rollup-plugin-cleanup": "^3.2.1",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-postcss": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -177,7 +177,7 @@ module.exports = (apiKey, { target = '#placekit', ...initOptions } = {}) => {
   // States
   // ----------------------------------------
   // internal
-  let userValue = '';
+  let userValue = null;
   let suggestions = [];
 
   /**
@@ -237,9 +237,15 @@ module.exports = (apiKey, { target = '#placekit', ...initOptions } = {}) => {
 
   /**
    * Restore backed-up user value
+   * @arg {bool} [clear] clear backed-up user value
    */
-  function restoreValue() {
-    input.value = userValue;
+  function restoreValue(clear = false) {
+    if (userValue !== null) {
+      input.value = userValue;
+      if (clear) {
+        userValue = null;
+      }
+    }
   }
 
   /**
@@ -391,7 +397,7 @@ module.exports = (apiKey, { target = '#placekit', ...initOptions } = {}) => {
     storeValue();
     setState({
       dirty: true,
-      empty: !input.value.trim(),
+      empty: !input.value,
       freeForm: true,
     });
   }
@@ -413,7 +419,7 @@ module.exports = (apiKey, { target = '#placekit', ...initOptions } = {}) => {
    */
   function onClickOutside(e) {
     if (![input, suggestionsPanel].includes(e.target) && !suggestionsPanel.contains(e.target)) {
-      restoreValue();
+      restoreValue(true);
       togglePanel(false);
     }
   }
@@ -458,7 +464,7 @@ module.exports = (apiKey, { target = '#placekit', ...initOptions } = {}) => {
         case 'Escape':
           if (isPanelOpen) {
             e.preventDefault();
-            restoreValue();
+            restoreValue(true);
             togglePanel(false);
           }
           break;


### PR DESCRIPTION
- Fix a bug when clicking anywhere outside the autocomplete would clear its default value.
- Remove `.trim()` when computing `state.empty`.