### PR TITLE
Fix React onChange and expose setValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,29 +404,19 @@ pka.clear();
 
 ### `pka.setValue()`
 
-Manually set the input value with full control on dispatching events or not, focusing input or not, updating the state or not. Useful for third-party wrappers like React.
+Manually set the input value. Useful for third-party wrappers like React.
 
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `value` | `string | null` (optional) | New input value, operation ignored if `undefined` or `null`. |
-| `opts` | `key-value mapping` (optional) | Options. |
-| `opts.notify` | `boolean` (optional) | Pass `true` to dispatch `change` and `input` events and update state (default `false`). |
-| `opts.focus` | `boolean` (optional) | Focus input if `true` (default `true`). |
-| `state` | `state` (optional) | Updated state (only if `notify: true`) [see `pka.state`](#pkastate). |
+| `notify` | `boolean` (optional) | Pass `true` to dispatch `change` and `input` events and update state (default `false`). |
 
 ```js
-pka.setValue(
-  'new value',
-  {
-    notify: true, // dispatch `change` and `input` event
-  },
-  {
-    isDirty: true, // set `isDirty` to `true`
-  }
-);
+pka.setValue('new value');
+pka.setValue('new value', true); // dispatch `change` and `input` event
 ```
 
-**NOTE**: `state.empty` will automatically be updated based on the input value if `notify: true`, but passing `{ empty: false }` as third argument will override it.
+**NOTE**: `state.empty` will automatically be updated based on the input value if `notify: true`. `state.dirty` and `state.freeForm` remain unchanged until the user focuses the input.
 
 ### `pka.destroy()`
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ If you have trouble importing CSS from `node_modules`, copy/paste [its content](
 - [`pka.open()`](#pkaopen)
 - [`pka.close()`](#pkaclose)
 - [`pka.clear()`](#pkaclear)
+- [`pka.setValue()`](#pkasetvalue)
 - [`pka.destroy()`](#pkadestroy)
 
 ### `placekitAutocomplete()`
@@ -400,6 +401,32 @@ Clears the input value, focus the field, and closes the suggestion panel.
 ```js
 pka.clear();
 ```
+
+### `pka.setValue()`
+
+Manually set the input value with full control on dispatching events or not, focusing input or not, updating the state or not. Useful for third-party wrappers like React.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `value` | `string | null` (optional) | New input value, operation ignored if `undefined` or `null`. |
+| `opts` | `key-value mapping` (optional) | Options. |
+| `opts.notify` | `boolean` (optional) | Pass `true` to dispatch `change` and `input` events and update state (default `false`). |
+| `opts.focus` | `boolean` (optional) | Focus input if `true` (default `true`). |
+| `state` | `state` (optional) | Updated state (only if `notify: true`) [see `pka.state`](#pkastate). |
+
+```js
+pka.setValue(
+  'new value',
+  {
+    notify: true, // dispatch `change` and `input` event
+  },
+  {
+    isDirty: true, // set `isDirty` to `true`
+  }
+);
+```
+
+**NOTE**: `state.empty` will automatically be updated based on the input value if `notify: true`, but passing `{ empty: false }` as third argument will override it.
 
 ### `pka.destroy()`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,6 +32,11 @@ export interface PKAClient {
   open(): PKAClient;
   close(): PKAClient;
   clear(): PKAClient;
+  setValue(
+    value?: string | null,
+    opts?: { notify?: boolean, focus?: boolean },
+    state?: Partial<PKAState>
+  ): PKAClient;
   destroy(): void;
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,11 +32,7 @@ export interface PKAClient {
   open(): PKAClient;
   close(): PKAClient;
   clear(): PKAClient;
-  setValue(
-    value?: string | null,
-    opts?: { notify?: boolean, focus?: boolean },
-    state?: Partial<PKAState>
-  ): PKAClient;
+  setValue(value?: string | null, notify?: boolean): PKAClient;
   destroy(): void;
 }
 


### PR DESCRIPTION
- Dispatch `input` event when value changes programmatically to trigger React `onChange` event.
- Trigger search only on human input by checking `event instanceof InputEvent` in `onInput()`.
- Rename `userValue` to `backupValue` and refactor to make use of it only when previewing values with the keyboard navigation (`moveActive()`) to prevent unnecessary value assignation side-effects.
- Move `setState()` out of `setValue()` (except for `state.empty`) to avoid confusion by forcing explicit declarations.
- Expose `pka.setValue()` for Autocomplete React to be able to update the input value with `defaultValue`. Could be useful for yet unknown edge cases too.
- Update README to add `pka.setValue()`.
- Update types.