### PR TITLE
Clear geolocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ If you have trouble importing CSS from `node_modules`, copy/paste [its content](
 - [`pka.on()`](#pkaon)
 - [`pka.handlers`](#pkahandlers)
 - [`pka.requestGeolocation()`](#pkarequestGeolocation)
+- [`pka.clearGeolocation()`](#pkaclearGeolocation)
 - [`pka.open()`](#pkaopen)
 - [`pka.close()`](#pkaclose)
 - [`pka.clear()`](#pkaclear)
@@ -377,6 +378,17 @@ pka.requestGeolocation({ timeout: 10000 }).then((pos) => console.log(pos.coords)
 | `cancelUpdate` | `boolean` (optional) | If `false` (default), suggestions list updates immediately based on device location. |
 
 The location will be store in the `coordinates` global options, you can still manually override it.
+`state.geolocation` will be set to `true`, dispatching both the `geolocation` and `state` events.
+
+### `pka.clearGeolocation()`
+
+Clear device's geolocation stored with [`pka.requestGeolocation`](#pkarequestGeolocation).
+
+```js
+pka.clearGeolocation();
+```
+
+The global option `coordinates` will be deleted and the `state.geolocation` will be set to `false`, dispatching both the `geolocation` and `state` events.
 
 ### `pka.open()`
 

--- a/examples/autocomplete-js-svelte/src/routes/+page.svelte
+++ b/examples/autocomplete-js-svelte/src/routes/+page.svelte
@@ -12,8 +12,8 @@
 		client = placekitAutocomplete(env.PUBLIC_PLACEKIT_API_KEY, {
 			target: input,
 			countries: ['fr'],
-		}).on('state', ({ ...newState }) => {
-			state = newState; // spread to force update state with new value
+		}).on('state', (newState) => {
+			state = { ...newState }; // spread to force update state with new value
 		});
 
 		// inject initial state from client

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@placekit/client-js": "^1.0.0",
+        "@placekit/client-js": "^1.1.0",
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
-        "@rollup/plugin-commonjs": "^25.0.1",
+        "@rollup/plugin-commonjs": "^25.0.2",
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@rollup/plugin-replace": "^5.0.2",
         "autoprefixer": "^10.4.14",
-        "eslint": "^8.42.0",
+        "eslint": "^8.43.0",
         "eslint-config-google": "^0.14.0",
         "npm-watch": "^0.11.0",
         "postcss": "^8.4.24",
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
-      "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
+      "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -252,9 +252,9 @@
       }
     },
     "node_modules/@placekit/client-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0.tgz",
-      "integrity": "sha512-dexlsVUJi/4e+zRON2vZYLufT3kIyWe+IgQXd6Nu6y6KuldrAycwir/1AGk2cZliSRgiox+0P5Xx96EIVlxxKA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.1.0.tgz",
+      "integrity": "sha512-YisVSR9J2Pt8EA1DcdlltKN/exrr3L2GvMF4gzvehyZqUNIooKPFPqL1eyauboygl+hkRL4YP0bOTjPz3r61lw=="
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -266,9 +266,9 @@
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.1.tgz",
-      "integrity": "sha512-2DJ4kv4b1xfTJopWhu61ANdNRHvzQZ2fpaIrlgaP2jOfUv1wDJ0Ucqy8AZlbFmn/iUjiwKoqki9j55Y6L8kyNQ==",
+      "version": "25.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.2.tgz",
+      "integrity": "sha512-NGTwaJxIO0klMs+WSFFtBP7b9TdTJ3K76HZkewT8/+yHzMiUGVQgaPtLQxNVYIgT5F7lxkEyVID+yS3K7bhCow==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
@@ -1155,15 +1155,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
-      "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
+      "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.42.0",
+        "@eslint/js": "8.43.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -3909,9 +3909,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
-      "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
+      "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
       "dev": true
     },
     "@humanwhocodes/config-array": {
@@ -4008,9 +4008,9 @@
       "optional": true
     },
     "@placekit/client-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0.tgz",
-      "integrity": "sha512-dexlsVUJi/4e+zRON2vZYLufT3kIyWe+IgQXd6Nu6y6KuldrAycwir/1AGk2cZliSRgiox+0P5Xx96EIVlxxKA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.1.0.tgz",
+      "integrity": "sha512-YisVSR9J2Pt8EA1DcdlltKN/exrr3L2GvMF4gzvehyZqUNIooKPFPqL1eyauboygl+hkRL4YP0bOTjPz3r61lw=="
     },
     "@popperjs/core": {
       "version": "2.11.8",
@@ -4018,9 +4018,9 @@
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@rollup/plugin-commonjs": {
-      "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.1.tgz",
-      "integrity": "sha512-2DJ4kv4b1xfTJopWhu61ANdNRHvzQZ2fpaIrlgaP2jOfUv1wDJ0Ucqy8AZlbFmn/iUjiwKoqki9j55Y6L8kyNQ==",
+      "version": "25.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.2.tgz",
+      "integrity": "sha512-NGTwaJxIO0klMs+WSFFtBP7b9TdTJ3K76HZkewT8/+yHzMiUGVQgaPtLQxNVYIgT5F7lxkEyVID+yS3K7bhCow==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^5.0.1",
@@ -4644,15 +4644,15 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
-      "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
+      "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.42.0",
+        "@eslint/js": "8.43.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "format": "eslint ./src --fix"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^25.0.1",
+    "@rollup/plugin-commonjs": "^25.0.2",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-replace": "^5.0.2",
     "autoprefixer": "^10.4.14",
-    "eslint": "^8.42.0",
+    "eslint": "^8.43.0",
     "eslint-config-google": "^0.14.0",
     "npm-watch": "^0.11.0",
     "postcss": "^8.4.24",
@@ -55,7 +55,7 @@
     "rollup-plugin-postcss": "^4.0.2"
   },
   "dependencies": {
-    "@placekit/client-js": "^1.0.0",
+    "@placekit/client-js": "^1.1.0",
     "@popperjs/core": "^2.11.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,6 +29,7 @@ export interface PKAClient {
   readonly handlers: Partial<PKAHandlers>;
   readonly state: PKAState;
   requestGeolocation(opts?: Object, cancelUpdate?: boolean): Promise<GeolocationPosition>;
+  clearGeolocation(): PKAClient;
   open(): PKAClient;
   close(): PKAClient;
   clear(): PKAClient;

--- a/src/index.js
+++ b/src/index.js
@@ -802,5 +802,16 @@ module.exports = (apiKey, { target = '#placekit', ...initOptions } = {}) => {
     });
   };
 
+  /**
+   * Clear device's location
+   * @memberof client
+   * @return {client}
+   */
+  client.clearGeolocation = () => {
+    pk.clearGeolocation();
+    setState({ geolocation: false });
+    return client;
+  };
+
   return client;
 };


### PR DESCRIPTION
- Add `client.clearGeolocation()` method from [ClientJS v1.1.0](https://github.com/placekit/client-js/releases/tag/v1.1.0).
- Update options and states (events `geolocation` and `state` are fired).
- Upgrade dependencies.
- Update README.