### PR TITLE
Update client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For React implementations, check our [PlaceKit Autocomplete React](https://githu
 
 ## ✨ Features
 
-- **Standalone** and **lightweight**: about 12kb of JS, and 4kb of CSS, gzipped
+- **Standalone** and **lightweight**: about 14kb of JS, and 4kb of CSS, gzipped
 - **Cross browser**: compatible across all major modern browsers
 - **Non-invasive**: use and style your own input element
 - **Customizable** and **extensible** with events and hooks
@@ -168,7 +168,7 @@ console.log(pka.options); // { "target": <input ... />, "language": "en", "maxRe
 | [`countryAutoFill`](#countryautofill-option) | Autocomplete | `boolean?` | `false` | Autofill current country by IP when `types: ['country']`. |
 | `className` | AutoComplete | `string` | `undefined` | Additional suggestions panel CSS class(es). |
 | `maxResults` | JS client | `integer` | `5` | Number of results per page. |
-| `language` | JS client | `string?` | `undefined` | Preferred language for the results<sup>[(1)](#ft1)</sup>, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. Defaults to the country's language. |
+| `language` | JS client | `string?` | `undefined` | Preferred language for the results<sup>[(1)](#ft1)</sup>, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. By default the results are displayed in their country's language. |
 | `types` | JS client | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |
 | [`countries`](#%EF%B8%8F-countries-option-is-required) | JS client | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes<sup>[(1)](#ft1)</sup>. |
 | [`countryByIP`](#countryByIP-option) | JS client | `boolean?` | `undefined` | Use IP to find user's country (turned off). |

--- a/examples/autocomplete-js-leaflet/src/main.js
+++ b/examples/autocomplete-js-leaflet/src/main.js
@@ -18,13 +18,14 @@ L.control.zoom({
 
 // set unique marker
 let marker;
-const updateMarker = (lat, lng) => {
+const updateMarker = (coords) => {
+  const [lat, lng] = coords.split(',');
   if (marker) {
     marker.setLatLng([lat, lng]);
   } else {
     marker = L.marker([lat, lng]).addTo(map);
   }
-  map.setView(marker.getLatLng(), 17);
+  map.setView(marker.getLatLng(), 16);
 };
 
 // instantiate PlaceKit Autocomplete JS
@@ -58,7 +59,7 @@ pka.on('empty', (empty) => {
 
 // add/update marker on pick/geolocation
 pka.on('pick', (_, item) => {
-  updateMarker(item.lat, item.lng);
+  updateMarker(item.coordinates);
 });
 pka.on('geolocation', (_, pos) => {
   updateMarker(pos.coords.latitude, pos.coords.longitude);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "@placekit/client-js": "^1.1.0",
+        "@placekit/client-js": "^1.1.1",
         "@popperjs/core": "^2.11.8"
       },
       "devDependencies": {
@@ -252,9 +252,9 @@
       }
     },
     "node_modules/@placekit/client-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.1.0.tgz",
-      "integrity": "sha512-YisVSR9J2Pt8EA1DcdlltKN/exrr3L2GvMF4gzvehyZqUNIooKPFPqL1eyauboygl+hkRL4YP0bOTjPz3r61lw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.1.1.tgz",
+      "integrity": "sha512-DK+WQiniT+CNLxpbPG4hS54Z3mqlEq3Mxbtgh3xHD43lf+67HKXKurc2x0iewaOLME0N9rZihfWISFau8nLqYA=="
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -4008,9 +4008,9 @@
       "optional": true
     },
     "@placekit/client-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.1.0.tgz",
-      "integrity": "sha512-YisVSR9J2Pt8EA1DcdlltKN/exrr3L2GvMF4gzvehyZqUNIooKPFPqL1eyauboygl+hkRL4YP0bOTjPz3r61lw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.1.1.tgz",
+      "integrity": "sha512-DK+WQiniT+CNLxpbPG4hS54Z3mqlEq3Mxbtgh3xHD43lf+67HKXKurc2x0iewaOLME0N9rZihfWISFau8nLqYA=="
     },
     "@popperjs/core": {
       "version": "2.11.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "rollup-plugin-postcss": "^4.0.2"
   },
   "dependencies": {
-    "@placekit/client-js": "^1.1.0",
+    "@placekit/client-js": "^1.1.1",
     "@popperjs/core": "^2.11.8"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,9 @@ const isObject = (v) => typeof v === 'object' && !Array.isArray(v) && v !== null
  * @prop {string} administrative
  * @prop {string} country
  * @prop {string} countrycode
- * @prop {number} lat
- * @prop {number} lng
+ * @prop {string} coordinates // "lat,lng"
+ * @prop {number} lat // deprecated
+ * @prop {number} lng // deprecated
  * @prop {string} type
  * @prop {string[]} zipcode
  * @prop {number} population


### PR DESCRIPTION
- Update Client JS to get updated typings (see https://github.com/placekit/client-js/pull/11):
  - Add `PKResult['coordinates']` (more conventional) and deprecate `PKResult['lat']` and `PKResult['lng']`.
  - Update `PKOptions['language']` to be `string`.
- Update [Leaflet example](./examples/autocomplete-js-leaflet) to use `item.coordinates` instead of `item.lat, item.lng`.
- Update GZip size in README from 12kb to 14kb.