### PR TITLE
Replace CSS visibility with opacity

### DIFF
--- a/src/placekit.css
+++ b/src/placekit.css
@@ -200,8 +200,8 @@ button.pka-input-clear[aria-hidden="true"] {
 .pka-suggestions {
   container-name: pka-suggestions;
   container-type: inline-size;
-  z-index: var(--pka-z-index);
-  visibility: hidden;
+  z-index: -1;
+  opacity: 0;
   pointer-events: none;
   overflow: hidden;
   min-width: 240px;
@@ -216,7 +216,8 @@ button.pka-input-clear[aria-hidden="true"] {
 }
 
 .pka-suggestions.pka-open {
-  visibility: visible;
+  z-index: var(--pka-z-index);
+  opacity: 1;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
Weird bug from support where on some iPhones the suggestions list would be empty. Removing CSS `visibility` property seems to work in that specific case.