### PR TITLE
Fix mouseover not applying active state

### DIFF
--- a/examples/autocomplete-js-countries-whitelist/.env.sample
+++ b/examples/autocomplete-js-countries-whitelist/.env.sample
@@ -1,0 +1,1 @@
+VITE_PLACEKIT_API_KEY=<your-api-key>

--- a/examples/autocomplete-js-countries-whitelist/.gitignore
+++ b/examples/autocomplete-js-countries-whitelist/.gitignore
@@ -1,0 +1,4 @@
+.env
+dist
+node_modules
+package-lock.json

--- a/examples/autocomplete-js-countries-whitelist/README.md
+++ b/examples/autocomplete-js-countries-whitelist/README.md
@@ -1,0 +1,31 @@
+# PlaceKit Autocomplete JS country field example
+
+[![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/placekit/autocomplete-js/tree/main/examples/autocomplete-js-countries)
+
+Make a country selector field with autocomplete JS, and automatically fill the current user's country (based on IP).
+
+Only using [TailwindCSS](https://tailwindcss.com) as a convenience for the basic styling of the example.
+
+## Run
+
+```sh
+# clone project and access this example
+git clone git@github.com:placekit/autocomplete-js.git
+cd autocomplete-js/examples/autocomplete-js-countries
+
+# install dependencies
+npm install
+
+# create .env file
+cp .env.sample .env
+```
+
+Open the `.env` file and replace `<your-api-key>` with your PlaceKit API key.
+
+Then run:
+
+```sh
+npm run dev
+```
+
+And your project will be served at http://localhost:5173.

--- a/examples/autocomplete-js-countries-whitelist/README.md
+++ b/examples/autocomplete-js-countries-whitelist/README.md
@@ -1,8 +1,9 @@
-# PlaceKit Autocomplete JS country field example
+# PlaceKit Autocomplete JS custom country selector (whitelist countries)
 
-[![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/placekit/autocomplete-js/tree/main/examples/autocomplete-js-countries)
+[![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?style=flat-square&logo=codesandbox)](https://githubbox.com/placekit/autocomplete-js/tree/main/examples/autocomplete-js-countries-whitelist)
 
-Make a country selector field with autocomplete JS, and automatically fill the current user's country (based on IP).
+Make a custom country selector to dynamically change the autocomplete country.
+In some use-cases, you may want control over the list of allowed countries. Our built-in country selector is actually a country search and we do not support whitelists (nor blacklists) at the moment. Therefore we suggest this example as a workaround.
 
 Only using [TailwindCSS](https://tailwindcss.com) as a convenience for the basic styling of the example.
 
@@ -11,7 +12,7 @@ Only using [TailwindCSS](https://tailwindcss.com) as a convenience for the basic
 ```sh
 # clone project and access this example
 git clone git@github.com:placekit/autocomplete-js.git
-cd autocomplete-js/examples/autocomplete-js-countries
+cd autocomplete-js/examples/autocomplete-js-countries-whitelist
 
 # install dependencies
 npm install

--- a/examples/autocomplete-js-countries-whitelist/package.json
+++ b/examples/autocomplete-js-countries-whitelist/package.json
@@ -1,0 +1,18 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.3",
+    "vite": "^4.4.11"
+  },
+  "dependencies": {
+    "@placekit/autocomplete-js": "^2.1.1"
+  }
+}

--- a/examples/autocomplete-js-countries-whitelist/postcss.config.cjs
+++ b/examples/autocomplete-js-countries-whitelist/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/examples/autocomplete-js-countries-whitelist/src/global.css
+++ b/examples/autocomplete-js-countries-whitelist/src/global.css
@@ -1,0 +1,4 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+@tailwind variants;

--- a/examples/autocomplete-js-countries-whitelist/src/index.html
+++ b/examples/autocomplete-js-countries-whitelist/src/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width" />
+  <title>PlaceKit Autocomplete JS country field</title>
+</head>
+<body class="py-32 bg-slate-50">
+  <main class="max-w-lg mx-auto flex items-stretch gap-2">
+    <select
+      name="country"
+      id="country"
+    >
+      <option value="">Select country</option>
+      <option value="fr">France</option>
+      <option value="be">Belgium</option>
+      <option value="ch">Swiss</option>
+    </select>
+    <div class="grow pka-input">
+      <button
+        type="button"
+        class="pka-input-clear"
+        title="Clear value"
+        id="placekit-clear"
+        aria-hidden="true"
+      >
+        <span class="pka-sr-only">Clear value</span>
+      </button>
+      <input
+        type="search"
+        name="address"
+        placeholder="Search address..."
+        id="placekit-input"
+      />
+    </div>
+  </main>
+
+  <script type="module" src="main.js"></script>
+</body>
+</html>

--- a/examples/autocomplete-js-countries-whitelist/src/main.js
+++ b/examples/autocomplete-js-countries-whitelist/src/main.js
@@ -1,0 +1,42 @@
+import placekitAutocomplete from '@placekit/autocomplete-js';
+
+import './global.css';
+import '@placekit/autocomplete-js/dist/placekit-autocomplete.css';
+
+// get default country value
+const countrySelect = document.querySelector('#country');
+const defaultValue = countrySelect.value;
+
+// instantiate PlaceKit Autocomplete JS
+const pka = placekitAutocomplete(import.meta.env.VITE_PLACEKIT_API_KEY, {
+  target: '#placekit-input',
+  countries: [defaultValue],
+  countrySelect: false,
+});
+
+// disable input if no default country selected
+if (!defaultValue) {
+  pka.input.setAttribute('disabled', true);
+}
+
+// clear input on click
+const clearButton = document.querySelector('#placekit-clear');
+clearButton.addEventListener('click', pka.clear);
+
+// hide clear button when input is empty
+pka.on('empty', (empty) => {
+  clearButton.setAttribute('aria-hidden', empty);
+});
+
+// custom country selector
+countrySelect.addEventListener('change', (e) => {
+  pka.configure({
+    countries: [e.target.value],
+  });
+  if (e.target.value) {
+    pka.input.removeAttribute('disabled');
+    pka.input.focus();
+  } else {
+    pka.input.setAttribute('disabled', true);
+  }
+});

--- a/examples/autocomplete-js-countries-whitelist/tailwind.config.js
+++ b/examples/autocomplete-js-countries-whitelist/tailwind.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  content: [
+    './src/**/*.html',
+    './src/**/*.js',
+  ],
+};

--- a/examples/autocomplete-js-countries-whitelist/vite.config.js
+++ b/examples/autocomplete-js-countries-whitelist/vite.config.js
@@ -1,0 +1,8 @@
+import path from 'node:path';
+import { defineConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  root: path.resolve(__dirname, 'src'),
+  envDir: path.resolve(__dirname),
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/src/placekit-autocomplete.css
+++ b/src/placekit-autocomplete.css
@@ -187,6 +187,11 @@ input.pka-input,
   padding: calc(var(--pka-scale) * .5) calc(var(--pka-scale) * .75);
 }
 
+.pka-input:not(input) input:disabled,
+input.pka-input:disabled {
+  cursor: not-allowed;
+}
+
 /* input geoloc/clear buttons
 ---------------------------------------- */
 button.pka-input-geolocation,

--- a/src/placekit-autocomplete.js
+++ b/src/placekit-autocomplete.js
@@ -334,11 +334,8 @@ export default function placekitAutocomplete(
   // Event handlers
   // ----------------------------------------
   // JS-handled hover state
-  let touchEvent;
-  panel.addEventListener('touchstart', () => touchEvent = true);
-  panel.addEventListener('end', () => touchEvent = true);
-  panel.addEventListener('mouseover', (e) => {
-    if (touchEvent || (!e.movementX && !e.movementY)) return;
+  panel.addEventListener('mousemove', (e) => {
+    if (!e.movementX && !e.movementY) return;
     clearActive();
     e.target.closest('[role="option"]')?.classList.add('pka-active');
   });


### PR DESCRIPTION
- Replace `mouseover` with `mousemove` event.
- Remove touch event detection, no longer needed.
- Add `cursor: not-allowed` on disabled input.
- Add countries custom select example.