### PR TITLE
Fix keyboard nav when input is empty and escape/clear input behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ pka.close();
 
 ### `pka.clear()`
 
-Clears the input value, focus the field, and closes the suggestion panel.
+Clears the input value, focus the field, closes the suggestion panel and clear suggestions if `state.geolocation` is false.
 
 ```js
 pka.clear();

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ pka.close();
 
 ### `pka.clear()`
 
-Clears the input value, focus the field, closes the suggestion panel and clear suggestions if `state.geolocation` is false.
+Clears the input value, focus the field, closes the suggestion panel and clear suggestions if `state.geolocation` is false or perform an empty search to reset geolocated suggestions otherwise.
 
 ```js
 pka.clear();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",


### PR DESCRIPTION
- Fix couldn't use keyboard navigation when input is empty and there are suggestions (when geolocation is active).
- Fix `state.empty` wasn't reset when pressing Esc.
- Close panel and clear suggestions on clearing input (either with Esc. key or `pka.clear`). If `state.geolocation`, perform an empty search instead.