### PR TITLE
Don't throw on geolocation error, add param to handler instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ pka.on('open', () => {})
   .on('dirty', (bool) => {})
   .on('empty', (bool) => {})
   .on('freeForm', (bool) => {})
-  .on('geolocation', (bool, position) => {});
+  .on('geolocation', (bool, position, error) => {});
   .on('countryMode', (bool) => {});
   .on('state', (state) => {})
   .on('countryChange', (item) => {});
@@ -339,6 +339,7 @@ Triggered when `state.geolocation` value changes (a.k.a. when `pka.requestGeoloc
 | --- | --- | --- |
 | `geolocation` | `boolean` | `true` if granted, `false` if denied. |
 | `position` | [`GeolocationPosition \| undefined`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPosition) | Passed when `geolocation` is `true`. |
+| `error` | [`string \| undefined`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPosition) | Geolocation request error message. |
 
 ##### `countryMode`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-js",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "@placekit/client-js": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-js",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete JavaScript library",
   "license": "MIT",

--- a/src/placekit-autocomplete.js
+++ b/src/placekit-autocomplete.js
@@ -623,8 +623,7 @@ export default function placekitAutocomplete(
       search();
       return pos;
     }).catch((err) => {
-      setState({ geolocation: false });
-      throw err;
+      setState({ geolocation: false }, undefined, err.message);
     });
   };
 


### PR DESCRIPTION
- Remove thrown error on `pka.requestGeolocation` fails.
- Add third param `error` to `geolocation` event for developers to handle the error.